### PR TITLE
Add offline GPT and task scheduler modules

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -60,3 +60,31 @@
 При первом запуске будут созданы базы данных. Используйте следующие учетные данные для входа:
 * **Логин:** `admin`
 * **Пароль:** `password123`
+
+## Дополнительные возможности
+
+### Локальный GPT-Neo
+Модель GPT-Neo (125M) загружается из директории `models/gpt-neo-125M` с использованием
+библиотеки `transformers`. Пример использования:
+
+```python
+from offline_gpt import LocalGPTAssistant
+
+assistant = LocalGPTAssistant()
+answer = assistant.generate("Как изменить IP в Astra Linux?")
+print(answer)
+```
+
+### Планировщик задач
+Модуль `scheduler.TaskScheduler` позволяет планировать запуск команд во времени.
+Задания хранятся в `db/tasks.db` и автоматически выполняются в фоновом потоке.
+Пример добавления задачи:
+
+```python
+from datetime import datetime, timedelta
+from scheduler import TaskScheduler
+
+sched = TaskScheduler(poll_interval=30)
+sched.start()
+sched.add_task("echo Hello", datetime.now() + timedelta(minutes=1))
+```

--- a/init.py
+++ b/init.py
@@ -13,6 +13,8 @@ from .macro_engine import MacroEngine
 from .auth_rbac import AuthManager, Role
 from .logging_audit import AuditLogger
 from .utils import AdvancedNLUParser
+from .offline_gpt import LocalGPTAssistant
+from .scheduler import TaskScheduler
 
 __all__ = [
     'IntentRouter',
@@ -26,4 +28,6 @@ __all__ = [
     'Role',
     'AuditLogger',
     'AdvancedNLUParser',
+    'LocalGPTAssistant',
+    'TaskScheduler',
 ]

--- a/offline_gpt.py
+++ b/offline_gpt.py
@@ -1,0 +1,42 @@
+"""offline_gpt.py
+Local GPT-Neo assistant for offline inference.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+
+class LocalGPTAssistant:
+    """Simple wrapper around GPT-Neo 125M for offline usage."""
+
+    def __init__(self, model_dir: str = "models/gpt-neo-125M"):
+        self.model_dir = model_dir
+        self.model: Optional[torch.nn.Module] = None
+        self.tokenizer: Optional[AutoTokenizer] = None
+
+    def load_model(self) -> None:
+        """Load model and tokenizer from ``self.model_dir``."""
+        if self.model is not None:
+            return
+        if not os.path.isdir(self.model_dir):
+            raise FileNotFoundError(
+                f"Model directory '{self.model_dir}' not found. Place the HF model there"
+            )
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_dir)
+        self.model = AutoModelForCausalLM.from_pretrained(self.model_dir)
+        self.model.eval()
+
+    def generate(self, prompt: str, max_length: int = 128) -> str:
+        """Generate response for ``prompt``."""
+        if self.model is None or self.tokenizer is None:
+            self.load_model()
+        inputs = self.tokenizer(prompt, return_tensors="pt")
+        with torch.no_grad():
+            output = self.model.generate(**inputs, max_length=max_length)
+        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        return text[len(prompt):].strip()
+

--- a/plugins/example_plugin.py
+++ b/plugins/example_plugin.py
@@ -1,0 +1,12 @@
+from plugin_api import PluginBase
+
+
+class ExamplePlugin(PluginBase):
+    """Simple example plugin demonstrating plugin API usage."""
+
+    def activate(self):
+        print("ExamplePlugin activated")
+
+    def deactivate(self):
+        print("ExamplePlugin deactivated")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ bcrypt==4.1.2
 cryptography==42.0.5
 pymorphy2==0.9.1
 rapidfuzz==3.6.2
+psutil==5.9.8
+transformers==4.40.0
+torch==2.2.2

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,99 @@
+"""scheduler.py
+Simple cron-like task scheduler using SQLite storage.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, List, Optional
+
+DB_DIR = "db"
+SCHED_DB = os.path.join(DB_DIR, "tasks.db")
+
+
+@dataclass
+class ScheduledTask:
+    id: int
+    command: str
+    run_at: float
+    repeat: bool
+    retries: int = 0
+
+
+class TaskScheduler(threading.Thread):
+    """Background scheduler that executes tasks from SQLite."""
+
+    def __init__(self, poll_interval: int = 60):
+        super().__init__(daemon=True)
+        self.poll_interval = poll_interval
+        self.conn = sqlite3.connect(SCHED_DB, check_same_thread=False)
+        self._create_table()
+        self._stop_flag = threading.Event()
+
+    def _create_table(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                command TEXT NOT NULL,
+                run_at REAL NOT NULL,
+                repeat INTEGER NOT NULL,
+                retries INTEGER DEFAULT 0
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add_task(self, command: str, run_at: datetime, repeat: bool = False) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO tasks (command, run_at, repeat) VALUES (?, ?, ?)",
+            (command, run_at.timestamp(), int(repeat)),
+        )
+        self.conn.commit()
+
+    def run(self) -> None:
+        while not self._stop_flag.is_set():
+            self._check_tasks()
+            time.sleep(self.poll_interval)
+
+    def stop(self) -> None:
+        self._stop_flag.set()
+
+    def _check_tasks(self) -> None:
+        cur = self.conn.cursor()
+        now_ts = time.time()
+        rows = cur.execute(
+            "SELECT id, command, run_at, repeat, retries FROM tasks WHERE run_at <= ?",
+            (now_ts,),
+        ).fetchall()
+        for id_, cmd, ts, rep, retries in rows:
+            self._execute_task(id_, cmd, rep, retries)
+
+    def _execute_task(self, task_id: int, cmd: str, repeat: int, retries: int) -> None:
+        try:
+            subprocess.run(cmd, shell=True, check=True)
+            self._finish_task(task_id, bool(repeat))
+        except subprocess.CalledProcessError:
+            retries += 1
+            self.conn.execute(
+                "UPDATE tasks SET retries = ? WHERE id = ?", (retries, task_id)
+            )
+            self.conn.commit()
+
+    def _finish_task(self, task_id: int, repeat: bool) -> None:
+        if repeat:
+            next_time = datetime.now().timestamp() + 86400
+            self.conn.execute(
+                "UPDATE tasks SET run_at = ? WHERE id = ?", (next_time, task_id)
+            )
+        else:
+            self.conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        self.conn.commit()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import os
+import json
+import os
+import json
+import sys
+from datetime import datetime
+
+import pytest
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from auth_rbac import AuthManager, Role
+
+
+@pytest.fixture()
+def temp_auth_db(tmp_path):
+    return str(tmp_path / "auth.db")
+
+
+@pytest.fixture()
+def auth_manager(temp_auth_db):
+    return AuthManager(db_path=temp_auth_db)
+
+
+@pytest.fixture()
+def sample_commands_json(tmp_path):
+    data = {
+        "test.echo": {
+            "phrases": ["echo message"],
+            "params": {"msg": {"type": "string", "required": True}},
+            "templates": {"win": "echo {msg}", "astro": "echo {msg}"}
+        }
+    }
+    file_path = tmp_path / "commands.json"
+    with open(file_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+    return str(file_path)
+
+
+@pytest.fixture()
+def scheduler_db(tmp_path):
+    return str(tmp_path / "tasks.db")

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -1,0 +1,21 @@
+import pytest
+import pytest
+
+from auth_rbac import AuthManager, Role
+
+
+def test_user_creation_and_verification(temp_auth_db):
+    am = AuthManager(db_path=temp_auth_db)
+    assert am.add_user("bob", "secret", Role.OPERATOR)
+    assert am.verify_user("bob", "secret") == Role.OPERATOR
+    assert am.verify_user("bob", "bad") is None
+    cur = am.conn.cursor()
+    cur.execute("SELECT password_hash FROM users WHERE username=?", ("bob",))
+    stored = cur.fetchone()[0]
+    assert stored != "secret"
+
+
+def test_role_permissions():
+    am = AuthManager(db_path=":memory:")
+    assert am.is_allowed(Role.ADMIN, Role.OPERATOR)
+    assert not am.is_allowed(Role.OPERATOR, Role.ADMIN)

--- a/tests/core/test_auto_repair.py
+++ b/tests/core/test_auto_repair.py
@@ -1,0 +1,11 @@
+import pytest
+
+auto_repair = pytest.importorskip("auto_repair")
+
+
+def test_rule_matching(tmp_path):
+    sample = "rules:\n  - match: error\n    action: fix.sh"
+    cfg = tmp_path / "auto_repair.yaml"
+    cfg.write_text(sample)
+    rules = auto_repair.load_rules(str(cfg))
+    assert rules[0]["match"] == "error"

--- a/tests/core/test_plugin_loader.py
+++ b/tests/core/test_plugin_loader.py
@@ -1,0 +1,44 @@
+import sys
+
+from plugin_api import PluginManager, PluginBase
+
+
+
+class DummyContext:
+    pass
+
+
+def test_plugin_activation(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "plug"
+    plugins_dir.mkdir()
+    (plugins_dir / "__init__.py").write_text("")
+    plugin_code = (
+        "from plugin_api import PluginBase\n"
+        "class MyPlugin(PluginBase):\n"
+        "    def __init__(self, app_context=None):\n"
+        "        super().__init__(app_context)\n"
+        "        self.active = False\n"
+        "    def activate(self):\n        self.active=True\n"
+        "    def deactivate(self):\n        self.active=False\n"
+    )
+    (plugins_dir / "plg.py").write_text(plugin_code)
+    sys.path.insert(0, str(tmp_path))
+    pm = PluginManager(plugin_dir=plugins_dir.name, app_context=DummyContext())
+    pm.load_plugins()
+    assert len(pm.plugins) == 1
+    plugin = pm.plugins[0]
+    assert isinstance(plugin, PluginBase)
+    assert getattr(plugin, "active", False) is True
+    sys.path.pop(0)
+
+
+def test_plugin_load_error(tmp_path, capsys):
+    plugins_dir = tmp_path / "plug2"
+    plugins_dir.mkdir()
+    (plugins_dir / "__init__.py").write_text("")
+    (plugins_dir / "bad.py").write_text("def broken(")
+    pm = PluginManager(plugin_dir=plugins_dir.name)
+    pm.load_plugins()
+    captured = capsys.readouterr()
+    assert "Failed" in captured.out
+    assert len(pm.plugins) == 0

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+import time
+from datetime import datetime
+
+import pytest
+
+import scheduler
+
+
+def test_add_task_persists(monkeypatch, scheduler_db):
+    monkeypatch.setattr(scheduler, "SCHED_DB", scheduler_db)
+    sched = scheduler.TaskScheduler(poll_interval=0.01)
+    sched.add_task("echo hi", datetime.fromtimestamp(time.time()))
+    cur = sched.conn.cursor()
+    cur.execute("SELECT command FROM tasks")
+    assert cur.fetchone()[0] == "echo hi"
+
+
+def test_execute_task_success(monkeypatch, scheduler_db):
+    monkeypatch.setattr(scheduler, "SCHED_DB", scheduler_db)
+    sched = scheduler.TaskScheduler(poll_interval=0.01)
+    called = []
+    def fake_run(cmd, shell=True, check=True):
+        called.append(cmd)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    sched.add_task("echo hi", datetime.fromtimestamp(time.time()))
+    sched._check_tasks()
+    assert called == ["echo hi"]

--- a/tests/core/test_script_runner.py
+++ b/tests/core/test_script_runner.py
@@ -1,0 +1,44 @@
+import platform
+import subprocess
+
+from command_templates import CommandTemplates
+from sysadmin_actions import execute_intent
+
+
+class DummyPopen:
+    def __init__(self, *args, **kwargs):
+        self.stdout_lines = ["done\n"]
+        self.stderr_text = ""
+
+    def poll(self):
+        return 0
+
+    @property
+    def stdout(self):
+        class S:
+            def __init__(self, outer):
+                self.outer = outer
+            def readline(self):
+                return outer.stdout_lines.pop(0) if outer.stdout_lines else ""
+        outer = self
+        return S(self)
+
+    @property
+    def stderr(self):
+        class S:
+            def __init__(self, outer):
+                self.outer = outer
+            def read(self):
+                return outer.stderr_text
+        outer = self
+        return S(self)
+
+
+def test_execute_intent(monkeypatch, sample_commands_json):
+    ct = CommandTemplates()
+    ct.load_from_json(sample_commands_json)
+    outputs = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: DummyPopen())
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    execute_intent("test.echo", {"msg": "hi"}, ct, outputs.append)
+    assert any("hi" in o for o in outputs)

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -1,0 +1,8 @@
+import pytest
+
+telemetry = pytest.importorskip("telemetry")
+
+
+def test_metrics_keys():
+    data = telemetry.get_metrics()
+    assert set(data.keys()) >= {"cpu_percent", "memory_percent"}

--- a/tests/ui/test_chatops_ui.py
+++ b/tests/ui/test_chatops_ui.py
@@ -1,0 +1,11 @@
+import pytest
+
+chatops_ui = pytest.importorskip("chatops_ui")
+
+
+def test_run_suggested_command(qtbot):
+    ui = chatops_ui.ChatOpsUI()
+    qtbot.addWidget(ui)
+    ui.input.setText("test")
+    ui.on_send()
+    assert ui.chat_history.count() >= 1

--- a/tests/ui/test_command_console.py
+++ b/tests/ui/test_command_console.py
@@ -1,0 +1,18 @@
+from PyQt5.QtCore import Qt
+
+from app_new_ui import MainWindow, Role
+
+
+class DummyAuth:
+    def get_all_users(self):
+        return []
+
+
+def test_run_command_button(qtbot, sample_commands_json, monkeypatch):
+    monkeypatch.setattr("app_new_ui.COMMANDS_FILE", sample_commands_json)
+    monkeypatch.setattr("app_new_ui.FAVORITES_FILE", "missing.json")
+    window = MainWindow("tester", Role.OPERATOR, DummyAuth())
+    qtbot.addWidget(window)
+    window.nlu_input.setText("echo message")
+    window.on_nlu_enter()
+    assert window.current_intent == "test.echo"

--- a/tests/ui/test_login_flow.py
+++ b/tests/ui/test_login_flow.py
@@ -1,0 +1,30 @@
+from PyQt5.QtWidgets import QDialog
+
+from app_new_ui import LoginDialog, Role
+
+
+class DummyAuth:
+    def verify_user(self, username, password):
+        if username == "admin" and password == "secret":
+            return Role.ADMIN
+        return None
+
+
+def test_login_success(qtbot):
+    dialog = LoginDialog(DummyAuth())
+    qtbot.addWidget(dialog)
+    dialog.username_input.setText("admin")
+    dialog.password_input.setText("secret")
+    dialog.handle_login()
+    assert dialog.result() == QDialog.Accepted
+    assert dialog.user_role == Role.ADMIN
+
+
+def test_login_failure(qtbot):
+    dialog = LoginDialog(DummyAuth())
+    qtbot.addWidget(dialog)
+    dialog.username_input.setText("admin")
+    dialog.password_input.setText("bad")
+    dialog.handle_login()
+    assert dialog.user_role is None
+    assert dialog.status_label.text() != ""

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -1,0 +1,17 @@
+from PyQt5.QtWidgets import QApplication
+
+from app_new_ui import MainWindow, Role
+
+
+class DummyAuth:
+    def get_all_users(self):
+        return []
+
+
+def test_main_window_layout(qtbot, sample_commands_json, monkeypatch):
+    monkeypatch.setattr("app_new_ui.COMMANDS_FILE", sample_commands_json)
+    monkeypatch.setattr("app_new_ui.FAVORITES_FILE", "missing.json")
+    window = MainWindow(username="tester", user_role=Role.OPERATOR, auth_manager=DummyAuth())
+    qtbot.addWidget(window)
+    assert window.main_stack.count() >= 3
+    assert window.findChild(type(window.main_stack))

--- a/tests/ui/test_tree_panel.py
+++ b/tests/ui/test_tree_panel.py
@@ -1,0 +1,20 @@
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QTreeWidget
+
+from app_new_ui import MainWindow, Role
+
+
+class DummyAuth:
+    def get_all_users(self):
+        return []
+
+
+def test_tree_build(qtbot, sample_commands_json, monkeypatch):
+    monkeypatch.setattr("app_new_ui.COMMANDS_FILE", sample_commands_json)
+    monkeypatch.setattr("app_new_ui.FAVORITES_FILE", "missing.json")
+    window = MainWindow("tester", Role.OPERATOR, DummyAuth())
+    qtbot.addWidget(window)
+    tree = window.function_tree
+    # Expect one command loaded from sample json
+    iterator = tree.findItems("", Qt.MatchContains | Qt.MatchRecursive)
+    assert len(iterator) >= 1


### PR DESCRIPTION
## Summary
- add local GPT-Neo assistant wrapper
- introduce SQLite based task scheduler
- document new modules in README
- expose new helpers in package
- provide example plugin architecture
- update dependencies for new modules

## Testing
- `python -m py_compile *.py plugins/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686b813c9e0083279874fb441a9f8eb3